### PR TITLE
Revert "Bump rack from 2.0.5 to 2.0.7"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       activesupport (>= 3.1)
     parallel (1.12.1)
     public_suffix (3.0.3)
-    rack (2.0.7)
+    rack (2.0.5)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)


### PR DESCRIPTION
Reverts morishin/tabs.morishin.me#1